### PR TITLE
Add Flutter & Flask demo with SEAL encryption

### DIFF
--- a/flutter_app/android/app/build.gradle
+++ b/flutter_app/android/app/build.gradle
@@ -1,0 +1,27 @@
+apply plugin: 'com.android.application'
+
+android {
+    compileSdkVersion 33
+    defaultConfig {
+        applicationId "com.example.proximity_app"
+        minSdkVersion 23
+        targetSdkVersion 33
+        versionCode 1
+        versionName "1.0"
+        externalNativeBuild {
+            cmake {}
+        }
+        ndk {
+            abiFilters "arm64-v8a", "x86_64"
+        }
+    }
+    externalNativeBuild {
+        cmake {
+            path "src/main/cpp/CMakeLists.txt"
+        }
+    }
+}
+
+dependencies {
+    implementation 'androidx.appcompat:appcompat:1.5.1'
+}

--- a/flutter_app/android/app/src/main/AndroidManifest.xml
+++ b/flutter_app/android/app/src/main/AndroidManifest.xml
@@ -1,0 +1,17 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.proximity_app">
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+
+    <application
+        android:label="proximity_app"
+        android:icon="@mipmap/ic_launcher">
+        <activity
+            android:name="com.example.proximity_app.MainActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/flutter_app/android/app/src/main/cpp/CMakeLists.txt
+++ b/flutter_app/android/app/src/main/cpp/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.10.2)
+add_library(encrypt SHARED encrypt.cpp)
+
+include_directories(${CMAKE_SOURCE_DIR}/../../../native/seal/include)
+link_directories(${CMAKE_SOURCE_DIR}/../../../native/seal/lib)
+
+find_library(log-lib log)
+
+target_link_libraries(encrypt seal ${log-lib})

--- a/flutter_app/android/app/src/main/cpp/encrypt.cpp
+++ b/flutter_app/android/app/src/main/cpp/encrypt.cpp
@@ -1,0 +1,52 @@
+#include <seal/seal.h>
+#include <sstream>
+#include <vector>
+#include <string>
+#include <cstdlib>
+#include <cstring>
+
+using namespace seal;
+
+static std::string to_hex(const std::string &in) {
+    static const char *lut = "0123456789ABCDEF";
+    std::string out;
+    out.reserve(2 * in.size());
+    for (unsigned char c : in) {
+        out.push_back(lut[c >> 4]);
+        out.push_back(lut[c & 15]);
+    }
+    return out;
+}
+
+extern "C" char *encrypt_location(double lat, double lon) {
+    EncryptionParameters parms(scheme_type::bfv);
+    parms.set_poly_modulus_degree(4096);
+    parms.set_coeff_modulus(CoeffModulus::BFVDefault(4096));
+    parms.set_plain_modulus(PlainModulus::Batching(4096, 20));
+
+    SEALContext context(parms);
+    KeyGenerator keygen(context);
+    SecretKey sk = keygen.secret_key();
+    PublicKey pk;
+    keygen.create_public_key(pk);
+
+    BatchEncoder encoder(context);
+    Encryptor encryptor(context, pk);
+
+    std::vector<int64_t> vals = {(int64_t)(lat * 1e6), (int64_t)(lon * 1e6)};
+    Plaintext plain;
+    encoder.encode(vals, plain);
+    Ciphertext ct;
+    encryptor.encrypt(plain, ct);
+
+    std::stringstream ct_ss; ct.save(ct_ss);
+    std::stringstream sk_ss; sk.save(sk_ss);
+    std::stringstream pa_ss; parms.save(pa_ss);
+
+    std::string json = "{\"ct\":\"" + to_hex(ct_ss.str()) + "\",\"sk\":\"" + to_hex(sk_ss.str()) + "\",\"parms\":\"" + to_hex(pa_ss.str()) + "\"}";
+    char *out = (char*)malloc(json.size() + 1);
+    std::memcpy(out, json.c_str(), json.size() + 1);
+    return out;
+}
+
+extern "C" void free_string(char *ptr) { std::free(ptr); }

--- a/flutter_app/android/app/src/main/java/com/example/proximity_app/MainActivity.kt
+++ b/flutter_app/android/app/src/main/java/com/example/proximity_app/MainActivity.kt
@@ -1,0 +1,5 @@
+package com.example.proximity_app
+
+import io.flutter.embedding.android.FlutterActivity
+
+class MainActivity: FlutterActivity()

--- a/flutter_app/lib/main.dart
+++ b/flutter_app/lib/main.dart
@@ -1,0 +1,55 @@
+import 'dart:ffi';
+import 'dart:io';
+import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
+import 'package:location/location.dart';
+import 'package:ffi/ffi.dart';
+
+typedef _EncryptNative = Pointer<Utf8> Function(Double, Double);
+typedef _Encrypt = Pointer<Utf8> Function(double, double);
+typedef _FreeNative = Void Function(Pointer<Utf8>);
+typedef _Free = void Function(Pointer<Utf8>);
+
+final DynamicLibrary _lib = Platform.isAndroid
+    ? DynamicLibrary.open('libencrypt.so')
+    : DynamicLibrary.process();
+
+final _Encrypt _encrypt = _lib
+    .lookup<NativeFunction<_EncryptNative>>('encrypt_location')
+    .asFunction();
+final _Free _free = _lib
+    .lookup<NativeFunction<_FreeNative>>('free_string')
+    .asFunction();
+
+void main() {
+  runApp(const MyApp());
+}
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  Future<void> _send() async {
+    Location loc = Location();
+    final data = await loc.getLocation();
+    final ptr = _encrypt(data.latitude!, data.longitude!);
+    final jsonStr = ptr.toDartString();
+    _free(ptr);
+    await http.post(Uri.parse('http://10.0.2.2:5000/location'),
+        headers: {'Content-Type': 'application/json'}, body: jsonStr);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: Scaffold(
+        appBar: AppBar(title: const Text('Proximity App')),
+        body: Center(
+          child: ElevatedButton(
+            onPressed: _send,
+            child: const Text('Send Location'),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/flutter_app/pubspec.yaml
+++ b/flutter_app/pubspec.yaml
@@ -1,0 +1,17 @@
+name: proximity_app
+description: Demo app
+publish_to: 'none'
+version: 1.0.0
+
+environment:
+  sdk: ">=2.17.0 <3.0.0"
+
+dependencies:
+  flutter:
+    sdk: flutter
+  ffi: ^2.0.1
+  http: ^0.13.5
+  location: ^4.4.0
+
+flutter:
+  uses-material-design: true

--- a/server/app.py
+++ b/server/app.py
@@ -1,0 +1,49 @@
+from flask import Flask, request
+import binascii
+import math
+import seal
+
+app = Flask(__name__)
+
+
+def to_bytes(hex_str):
+    return binascii.unhexlify(hex_str.encode())
+
+
+def haversine(lat1, lon1, lat2, lon2):
+    R = 6371000
+    phi1, phi2 = math.radians(lat1), math.radians(lat2)
+    dphi = math.radians(lat2 - lat1)
+    dl = math.radians(lon2 - lon1)
+    a = math.sin(dphi/2)**2 + math.cos(phi1)*math.cos(phi2)*math.sin(dl/2)**2
+    return 2*R*math.atan2(math.sqrt(a), math.sqrt(1-a))
+
+
+@app.route('/location', methods=['POST'])
+def location():
+    data = request.get_json()
+    parms = seal.EncryptionParameters()
+    parms.load(to_bytes(data['parms']))
+    context = seal.SEALContext(parms)
+    sk = seal.SecretKey()
+    sk.load(context, to_bytes(data['sk']))
+    decryptor = seal.Decryptor(context, sk)
+    encoder = seal.BatchEncoder(context)
+
+    ct = seal.Ciphertext()
+    ct.load(context, to_bytes(data['ct']))
+    plain = seal.Plaintext()
+    decryptor.decrypt(ct, plain)
+    decoded = encoder.decode_int64(plain)
+    lat, lon = decoded[0] / 1e6, decoded[1] / 1e6
+
+    lat_a, lon_a = 37.421998, -122.084
+    if haversine(lat, lon, lat_a, lon_a) < 100:
+        print('ALERT')
+    else:
+        print('Distance:', haversine(lat, lon, lat_a, lon_a))
+    return 'OK'
+
+
+if __name__ == '__main__':
+    app.run()


### PR DESCRIPTION
## Summary
- create minimal Flutter client app with location fetching
- encrypt location via Microsoft SEAL using an FFI C++ library
- post ciphertext JSON to a Flask server
- server decrypts and prints alert if location within 100m of reference point

## Testing
- `apt-get update && apt-get install -y tree`


------
https://chatgpt.com/codex/tasks/task_e_6882cd85aca48325a6540d9e81c447ed