### PR TITLE
Add invite flow and tracking support; update Flutter UI and iOS setup notes

### DIFF
--- a/flutter_app/android/app/build.gradle
+++ b/flutter_app/android/app/build.gradle
@@ -1,0 +1,27 @@
+apply plugin: 'com.android.application'
+
+android {
+    compileSdkVersion 33
+    defaultConfig {
+        applicationId "com.example.proximity_app"
+        minSdkVersion 23
+        targetSdkVersion 33
+        versionCode 1
+        versionName "1.0"
+        externalNativeBuild {
+            cmake {}
+        }
+        ndk {
+            abiFilters "arm64-v8a", "x86_64"
+        }
+    }
+    externalNativeBuild {
+        cmake {
+            path "src/main/cpp/CMakeLists.txt"
+        }
+    }
+}
+
+dependencies {
+    implementation 'androidx.appcompat:appcompat:1.5.1'
+}

--- a/flutter_app/android/app/src/main/AndroidManifest.xml
+++ b/flutter_app/android/app/src/main/AndroidManifest.xml
@@ -1,0 +1,17 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.proximity_app">
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+
+    <application
+        android:label="proximity_app"
+        android:icon="@mipmap/ic_launcher">
+        <activity
+            android:name="com.example.proximity_app.MainActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/flutter_app/android/app/src/main/cpp/CMakeLists.txt
+++ b/flutter_app/android/app/src/main/cpp/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.10.2)
+add_library(encrypt SHARED encrypt.cpp)
+
+include_directories(${CMAKE_SOURCE_DIR}/../../../native/seal/include)
+link_directories(${CMAKE_SOURCE_DIR}/../../../native/seal/lib)
+
+find_library(log-lib log)
+
+target_link_libraries(encrypt seal ${log-lib})

--- a/flutter_app/android/app/src/main/cpp/encrypt.cpp
+++ b/flutter_app/android/app/src/main/cpp/encrypt.cpp
@@ -1,0 +1,74 @@
+#include <seal/seal.h>
+#include <sstream>
+#include <vector>
+#include <string>
+#include <cstdlib>
+#include <cstring>
+
+using namespace seal;
+
+static std::string to_hex(const std::string &in) {
+    static const char *lut = "0123456789ABCDEF";
+    std::string out;
+    out.reserve(2 * in.size());
+    for (unsigned char c : in) {
+        out.push_back(lut[c >> 4]);
+        out.push_back(lut[c & 15]);
+    }
+    return out;
+}
+
+static std::string from_hex(const char *in) {
+    std::string out;
+    size_t len = std::strlen(in);
+    out.reserve(len / 2);
+    for (size_t i = 0; i + 1 < len; i += 2) {
+        char high = in[i];
+        char low = in[i + 1];
+        auto hex_to_val = [](char c) -> unsigned char {
+            if (c >= '0' && c <= '9') return c - '0';
+            if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+            if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+            return 0;
+        };
+        unsigned char val = (hex_to_val(high) << 4) | hex_to_val(low);
+        out.push_back(static_cast<char>(val));
+    }
+    return out;
+}
+
+extern "C" char *encrypt_location(const char *parms_hex,
+                                  const char *pk_hex,
+                                  double lat,
+                                  double lon) {
+    EncryptionParameters parms;
+    std::string parms_bytes = from_hex(parms_hex);
+    std::stringstream parms_ss;
+    parms_ss.write(parms_bytes.data(), parms_bytes.size());
+    parms.load(parms_ss);
+
+    SEALContext context(parms);
+    PublicKey pk;
+    std::string pk_bytes = from_hex(pk_hex);
+    std::stringstream pk_ss;
+    pk_ss.write(pk_bytes.data(), pk_bytes.size());
+    pk.load(context, pk_ss);
+
+    BatchEncoder encoder(context);
+    Encryptor encryptor(context, pk);
+
+    std::vector<int64_t> vals = {(int64_t)(lat * 1e6), (int64_t)(lon * 1e6)};
+    Plaintext plain;
+    encoder.encode(vals, plain);
+    Ciphertext ct;
+    encryptor.encrypt(plain, ct);
+
+    std::stringstream ct_ss;
+    ct.save(ct_ss);
+    std::string json = "{\"ct\":\"" + to_hex(ct_ss.str()) + "\"}";
+    char *out = (char*)malloc(json.size() + 1);
+    std::memcpy(out, json.c_str(), json.size() + 1);
+    return out;
+}
+
+extern "C" void free_string(char *ptr) { std::free(ptr); }

--- a/flutter_app/android/app/src/main/java/com/example/proximity_app/MainActivity.kt
+++ b/flutter_app/android/app/src/main/java/com/example/proximity_app/MainActivity.kt
@@ -1,0 +1,5 @@
+package com.example.proximity_app
+
+import io.flutter.embedding.android.FlutterActivity
+
+class MainActivity: FlutterActivity()

--- a/flutter_app/ios/README.md
+++ b/flutter_app/ios/README.md
@@ -1,0 +1,16 @@
+# iOS / Xcode setup
+
+This Flutter project currently ships with Android-only build configuration.
+To open and run it in Xcode, generate the iOS platform files with the Flutter
+SDK and then open the workspace in Xcode:
+
+```bash
+flutter create --platforms=ios .
+open ios/Runner.xcworkspace
+```
+
+## Required iOS changes
+- Add location usage strings to `ios/Runner/Info.plist`:
+  - `NSLocationWhenInUseUsageDescription`
+- Build and link the Microsoft SEAL library for iOS (arm64) and add it to the
+  Runner target, then update the FFI dynamic library loading as needed.

--- a/flutter_app/lib/main.dart
+++ b/flutter_app/lib/main.dart
@@ -1,0 +1,384 @@
+import 'dart:convert';
+import 'dart:ffi';
+import 'dart:io';
+import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
+import 'package:location/location.dart';
+import 'package:ffi/ffi.dart';
+
+typedef _EncryptNative = Pointer<Utf8> Function(
+    Pointer<Utf8>, Pointer<Utf8>, Double, Double);
+typedef _Encrypt = Pointer<Utf8> Function(
+    Pointer<Utf8>, Pointer<Utf8>, double, double);
+typedef _FreeNative = Void Function(Pointer<Utf8>);
+typedef _Free = void Function(Pointer<Utf8>);
+
+final DynamicLibrary _lib = Platform.isAndroid
+    ? DynamicLibrary.open('libencrypt.so')
+    : DynamicLibrary.process();
+
+final _Encrypt _encrypt = _lib
+    .lookup<NativeFunction<_EncryptNative>>('encrypt_location')
+    .asFunction();
+final _Free _free = _lib
+    .lookup<NativeFunction<_FreeNative>>('free_string')
+    .asFunction();
+
+void main() {
+  runApp(const MyApp());
+}
+
+class MyApp extends StatefulWidget {
+  const MyApp({super.key});
+
+  @override
+  State<MyApp> createState() => _MyAppState();
+}
+
+class _MyAppState extends State<MyApp> {
+  String _status = 'Ready';
+  String? _parmsHex;
+  String? _publicKeyHex;
+  bool _sending = false;
+  bool _loadingKeys = false;
+  final TextEditingController _userController = TextEditingController();
+  final TextEditingController _targetController = TextEditingController();
+  List<String> _incomingRequests = [];
+  String _requestStatus = 'No requests';
+
+  @override
+  void initState() {
+    super.initState();
+    _loadParams();
+  }
+
+  @override
+  void dispose() {
+    _userController.dispose();
+    _targetController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _loadParams() async {
+    if (_loadingKeys) return;
+    setState(() {
+      _loadingKeys = true;
+      _status = 'Loading encryption keys...';
+    });
+    try {
+      final response = await http.get(Uri.parse('http://10.0.2.2:5000/params'));
+      if (!mounted) return;
+      if (response.statusCode != 200) {
+        setState(() => _status = 'Key fetch failed (${response.statusCode})');
+        return;
+      }
+      if (response.body.isEmpty) {
+        setState(() => _status = 'Key fetch failed (empty response)');
+        return;
+      }
+      final map = Map<String, dynamic>.from(
+          jsonDecode(response.body) as Map<String, dynamic>);
+      final parms = map['parms'] as String?;
+      final pk = map['pk'] as String?;
+      if (parms == null || pk == null) {
+        setState(() => _status = 'Key fetch failed (missing fields)');
+        return;
+      }
+      setState(() {
+        _parmsHex = parms;
+        _publicKeyHex = pk;
+        _status = 'Ready';
+      });
+    } catch (err) {
+      if (!mounted) return;
+      setState(() => _status = 'Key fetch error: $err');
+    } finally {
+      if (!mounted) return;
+      setState(() => _loadingKeys = false);
+    }
+  }
+
+  Future<void> _send() async {
+    if (_sending) return;
+    final userId = _userController.text.trim();
+    if (userId.isEmpty) {
+      setState(() => _status = 'Enter your user ID');
+      return;
+    }
+    if (_parmsHex == null || _publicKeyHex == null) {
+      await _loadParams();
+      if (_parmsHex == null || _publicKeyHex == null) {
+        return;
+      }
+    }
+
+    final loc = Location();
+    try {
+      setState(() {
+        _sending = true;
+        _status = 'Requesting location...';
+      });
+      var serviceEnabled = await loc.serviceEnabled();
+      if (!serviceEnabled) {
+        serviceEnabled = await loc.requestService();
+        if (!serviceEnabled) {
+          setState(() => _status = 'Location service disabled');
+          setState(() => _sending = false);
+          return;
+        }
+      }
+
+      var permission = await loc.hasPermission();
+      if (permission == PermissionStatus.denied) {
+        permission = await loc.requestPermission();
+      }
+      if (permission == PermissionStatus.deniedForever) {
+        setState(() => _status = 'Location permission permanently denied');
+        setState(() => _sending = false);
+        return;
+      }
+      if (permission != PermissionStatus.granted) {
+        setState(() => _status = 'Location permission denied');
+        setState(() => _sending = false);
+        return;
+      }
+
+      final data = await loc.getLocation();
+      final latitude = data.latitude;
+      final longitude = data.longitude;
+      if (latitude == null || longitude == null) {
+        setState(() => _status = 'Location unavailable');
+        setState(() => _sending = false);
+        return;
+      }
+
+      setState(() => _status = 'Encrypting...');
+      final parmsPtr = _parmsHex!.toNativeUtf8();
+      final pkPtr = _publicKeyHex!.toNativeUtf8();
+      final ptr = _encrypt(parmsPtr, pkPtr, latitude, longitude);
+      malloc.free(parmsPtr);
+      malloc.free(pkPtr);
+      final jsonStr = ptr.toDartString();
+      _free(ptr);
+
+      setState(() => _status = 'Sending...');
+      final payload = Map<String, dynamic>.from(
+          jsonDecode(jsonStr) as Map<String, dynamic>);
+      payload['user'] = userId;
+      final response = await http.post(
+        Uri.parse('http://10.0.2.2:5000/location'),
+        headers: {'Content-Type': 'application/json'},
+        body: jsonEncode(payload),
+      );
+      if (!mounted) return;
+      setState(() => _status = 'Sent (${response.statusCode})');
+    } catch (err) {
+      if (!mounted) return;
+      setState(() => _status = 'Error: $err');
+    } finally {
+      if (!mounted) return;
+      setState(() => _sending = false);
+    }
+  }
+
+  Future<void> _sendRequest() async {
+    final userId = _userController.text.trim();
+    final targetId = _targetController.text.trim();
+    if (userId.isEmpty || targetId.isEmpty) {
+      setState(() => _requestStatus = 'Enter both user IDs');
+      return;
+    }
+    setState(() => _requestStatus = 'Sending request...');
+    try {
+      final response = await http.post(
+        Uri.parse('http://10.0.2.2:5000/request'),
+        headers: {'Content-Type': 'application/json'},
+        body: jsonEncode({'from': userId, 'to': targetId}),
+      );
+      if (!mounted) return;
+      setState(() => _requestStatus = 'Request sent (${response.statusCode})');
+    } catch (err) {
+      if (!mounted) return;
+      setState(() => _requestStatus = 'Request error: $err');
+    }
+  }
+
+  Future<void> _loadRequests() async {
+    final userId = _userController.text.trim();
+    if (userId.isEmpty) {
+      setState(() => _requestStatus = 'Enter your user ID');
+      return;
+    }
+    setState(() => _requestStatus = 'Checking requests...');
+    try {
+      final response = await http.get(
+        Uri.parse('http://10.0.2.2:5000/requests/$userId'),
+      );
+      if (!mounted) return;
+      if (response.statusCode != 200) {
+        setState(() => _requestStatus = 'Request check failed');
+        return;
+      }
+      final data = jsonDecode(response.body) as Map<String, dynamic>;
+      final requests = List<String>.from(data['requests'] ?? []);
+      setState(() {
+        _incomingRequests = requests;
+        _requestStatus =
+            requests.isEmpty ? 'No pending requests' : 'Pending requests';
+      });
+    } catch (err) {
+      if (!mounted) return;
+      setState(() => _requestStatus = 'Request check error: $err');
+    }
+  }
+
+  Future<void> _respondRequest(String fromUser, bool accepted) async {
+    final userId = _userController.text.trim();
+    if (userId.isEmpty) {
+      setState(() => _requestStatus = 'Enter your user ID');
+      return;
+    }
+    setState(() => _requestStatus = 'Sending response...');
+    try {
+      final response = await http.post(
+        Uri.parse('http://10.0.2.2:5000/respond'),
+        headers: {'Content-Type': 'application/json'},
+        body: jsonEncode(
+          {'from': fromUser, 'to': userId, 'accepted': accepted},
+        ),
+      );
+      if (!mounted) return;
+      _incomingRequests =
+          _incomingRequests.where((item) => item != fromUser).toList();
+      setState(() {
+        _requestStatus = 'Response sent (${response.statusCode})';
+      });
+    } catch (err) {
+      if (!mounted) return;
+      setState(() => _requestStatus = 'Response error: $err');
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: Scaffold(
+        appBar: AppBar(title: const Text('Proximity Alert')),
+        body: SafeArea(
+          child: Center(
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 360),
+              child: Padding(
+                padding: const EdgeInsets.all(16),
+                child: Card(
+                  elevation: 2,
+                  child: Padding(
+                    padding: const EdgeInsets.all(20),
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: [
+                        const Text(
+                          'Share your current location securely.',
+                          style: TextStyle(
+                            fontSize: 18,
+                            fontWeight: FontWeight.w600,
+                          ),
+                        ),
+                        const SizedBox(height: 8),
+                        const Text(
+                          'Your coordinates are encrypted on-device and sent to the '
+                          'local server for proximity checks.',
+                        ),
+                        const SizedBox(height: 16),
+                        TextField(
+                          controller: _userController,
+                          decoration: const InputDecoration(
+                            labelText: 'Your user ID',
+                            border: OutlineInputBorder(),
+                          ),
+                        ),
+                        const SizedBox(height: 12),
+                        ElevatedButton(
+                          onPressed: _sending ? null : _send,
+                          child: Text(_sending ? 'Sending...' : 'Send Location'),
+                        ),
+                        const SizedBox(height: 8),
+                        OutlinedButton(
+                          onPressed: _loadingKeys ? null : _loadParams,
+                          child: Text(
+                            _loadingKeys ? 'Refreshing Keys...' : 'Refresh Keys',
+                          ),
+                        ),
+                        const SizedBox(height: 16),
+                        Text(
+                          _status,
+                          textAlign: TextAlign.center,
+                          style: TextStyle(
+                            color: _status.startsWith('Error') ||
+                                    _status.contains('failed') ||
+                                    _status.contains('denied')
+                                ? Colors.red
+                                : Colors.black87,
+                          ),
+                        ),
+                        const Divider(height: 32),
+                        const Text(
+                          'Invite someone to track with you',
+                          style: TextStyle(fontWeight: FontWeight.w600),
+                        ),
+                        const SizedBox(height: 8),
+                        TextField(
+                          controller: _targetController,
+                          decoration: const InputDecoration(
+                            labelText: 'Person to invite',
+                            border: OutlineInputBorder(),
+                          ),
+                        ),
+                        const SizedBox(height: 8),
+                        ElevatedButton(
+                          onPressed: _sendRequest,
+                          child: const Text('Send Invite'),
+                        ),
+                        const SizedBox(height: 8),
+                        OutlinedButton(
+                          onPressed: _loadRequests,
+                          child: const Text('Check Incoming Requests'),
+                        ),
+                        const SizedBox(height: 8),
+                        ..._incomingRequests.map(
+                          (requester) => Row(
+                            children: [
+                              Expanded(child: Text('Request from $requester')),
+                              TextButton(
+                                onPressed: () =>
+                                    _respondRequest(requester, true),
+                                child: const Text('Accept'),
+                              ),
+                              TextButton(
+                                onPressed: () =>
+                                    _respondRequest(requester, false),
+                                child: const Text('Decline'),
+                              ),
+                            ],
+                          ),
+                        ),
+                        if (_incomingRequests.isEmpty)
+                          const Text('No pending requests'),
+                        const SizedBox(height: 8),
+                        Text(
+                          _requestStatus,
+                          textAlign: TextAlign.center,
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/flutter_app/pubspec.yaml
+++ b/flutter_app/pubspec.yaml
@@ -1,0 +1,17 @@
+name: proximity_app
+description: Demo app
+publish_to: 'none'
+version: 1.0.0
+
+environment:
+  sdk: ">=2.17.0 <3.0.0"
+
+dependencies:
+  flutter:
+    sdk: flutter
+  ffi: ^2.0.1
+  http: ^0.13.5
+  location: ^4.4.0
+
+flutter:
+  uses-material-design: true

--- a/server/app.py
+++ b/server/app.py
@@ -1,0 +1,111 @@
+from flask import Flask, request, jsonify
+import binascii
+import math
+import seal
+
+app = Flask(__name__)
+
+def to_hex(raw_bytes):
+    return binascii.hexlify(raw_bytes).decode()
+
+def to_bytes(hex_str):
+    return binascii.unhexlify(hex_str.encode())
+
+def create_context():
+    parms = seal.EncryptionParameters(seal.scheme_type.bfv)
+    parms.set_poly_modulus_degree(4096)
+    parms.set_coeff_modulus(seal.CoeffModulus.BFVDefault(4096))
+    parms.set_plain_modulus(seal.PlainModulus.Batching(4096, 20))
+    context = seal.SEALContext(parms)
+    keygen = seal.KeyGenerator(context)
+    sk = keygen.secret_key()
+    pk = keygen.create_public_key()
+    encoder = seal.BatchEncoder(context)
+    return parms, context, sk, pk, encoder
+
+PARMS, CONTEXT, SECRET_KEY, PUBLIC_KEY, ENCODER = create_context()
+PARMS_HEX = to_hex(PARMS.save())
+PUBLIC_KEY_HEX = to_hex(PUBLIC_KEY.save())
+PENDING_REQUESTS = {}
+ACTIVE_PAIRS = set()
+LATEST_LOCATIONS = {}
+
+def pair_key(user_a, user_b):
+    return tuple(sorted([user_a, user_b]))
+
+
+def haversine(lat1, lon1, lat2, lon2):
+    R = 6371000
+    phi1, phi2 = math.radians(lat1), math.radians(lat2)
+    dphi = math.radians(lat2 - lat1)
+    dl = math.radians(lon2 - lon1)
+    a = math.sin(dphi/2)**2 + math.cos(phi1)*math.cos(phi2)*math.sin(dl/2)**2
+    return 2*R*math.atan2(math.sqrt(a), math.sqrt(1-a))
+
+
+@app.route('/location', methods=['POST'])
+def location():
+    data = request.get_json()
+    user = data.get('user')
+    if not user:
+        return 'Missing user', 400
+    ct = seal.Ciphertext()
+    ct.load(CONTEXT, to_bytes(data['ct']))
+    decryptor = seal.Decryptor(CONTEXT, SECRET_KEY)
+    plain = seal.Plaintext()
+    decryptor.decrypt(ct, plain)
+    decoded = ENCODER.decode_int64(plain)
+    lat, lon = decoded[0] / 1e6, decoded[1] / 1e6
+
+    LATEST_LOCATIONS[user] = (lat, lon)
+    for pair in ACTIVE_PAIRS:
+        if user in pair:
+            other = pair[0] if pair[1] == user else pair[1]
+            other_loc = LATEST_LOCATIONS.get(other)
+            if other_loc:
+                distance = haversine(lat, lon, other_loc[0], other_loc[1])
+                if distance < 100:
+                    print('ALERT')
+                else:
+                    print('Distance:', distance)
+    return 'OK'
+
+@app.route('/params', methods=['GET'])
+def params():
+    return jsonify({'parms': PARMS_HEX, 'pk': PUBLIC_KEY_HEX})
+
+@app.route('/request', methods=['POST'])
+def request_participant():
+    data = request.get_json()
+    user_from = data.get('from')
+    user_to = data.get('to')
+    if not user_from or not user_to:
+        return 'Missing from/to', 400
+    PENDING_REQUESTS.setdefault(user_to, [])
+    if user_from not in PENDING_REQUESTS[user_to]:
+        PENDING_REQUESTS[user_to].append(user_from)
+    return 'OK'
+
+@app.route('/requests/<user>', methods=['GET'])
+def requests(user):
+    pending = PENDING_REQUESTS.get(user, [])
+    return jsonify({'requests': pending})
+
+@app.route('/respond', methods=['POST'])
+def respond():
+    data = request.get_json()
+    user_from = data.get('from')
+    user_to = data.get('to')
+    accepted = data.get('accepted')
+    if user_from is None or user_to is None or accepted is None:
+        return 'Missing response fields', 400
+    pending = PENDING_REQUESTS.get(user_to, [])
+    if user_from in pending:
+        pending.remove(user_from)
+    if accepted:
+        ACTIVE_PAIRS.add(pair_key(user_from, user_to))
+    return 'OK'
+
+
+if __name__ == '__main__':
+    app.run()


### PR DESCRIPTION
### Motivation
- Allow users to invite another user to participate in proximity tracking and only run proximity checks when both users have agreed, to avoid spurious alerts and enable an explicit sharing flow.
- Surface invite/request controls in the client so users can send, view, accept, and decline tracking requests while attaching a stable user identifier to location submissions.
- Provide guidance for generating an Xcode workspace and note iOS-specific requirements for building the project.

### Description
- Server: `server/app.py` now maintains `PENDING_REQUESTS`, `ACTIVE_PAIRS`, and `LATEST_LOCATIONS`, adds `pair_key` helper, and implements `/request`, `/requests/<user>`, and `/respond` endpoints; `/location` now requires a `user` field, stores the latest location per user, and only computes distances for accepted pairs before printing `ALERT` or the distance.
- Client: `flutter_app/lib/main.dart` was updated to add `TextEditingController`s for the local user ID and invite target, include the `user` field in the encrypted location payload, and implement `_sendRequest`, `_loadRequests`, and `_respondRequest` plus UI controls (send invite, check incoming requests, accept/decline) and request-status messaging.
- Docs: added `flutter_app/ios/README.md` describing how to generate the iOS/Xcode project and listing required changes (location usage strings and linking the SEAL library) to help run the app on iOS.

### Testing
- No automated test suite was available or executed for these changes.
- An attempt to run `flutter --version` in the rollout environment failed because the `flutter` binary is not present in this environment (command returned `command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6882cd85aca48325a6540d9e81c447ed)